### PR TITLE
Handle file upload reuse and cover heuristics

### DIFF
--- a/api/chat/stream.js
+++ b/api/chat/stream.js
@@ -129,10 +129,13 @@ function guessClientFrom(usersTxt = "") {
     if (dom) return titleCase(dom);
   }
   const m2 = usersTxt.match(/(?:Cliente|Empresa)\s*:\s*([^\n]+)/i);
-  if (m2?.[1])
-    return titleCase(
-      m2[1].replace(/\b(S\.?A\.?( de C\.?V\.?)?|SAS|SA|Ltd\.?|LLC|Studio|Estudio)\b/gi, "").trim()
-    );
+  if (m2?.[1]) {
+    const cleaned = m2[1]
+      .replace(/\b(S\.?A\.?( de C\.?V\.?)?|SAS|SA|Ltd\.?|LLC|Studio|Estudio)\b/gi, "")
+      .replace(/[.,\s]+$/g, "")
+      .trim();
+    if (cleaned) return titleCase(cleaned);
+  }
   return "Cliente";
 }
 
@@ -166,6 +169,8 @@ ${complete ? `<!-- AUTO_FINALIZE: ${JSON.stringify({ category: cat, client: cli 
 
   return `${progressLine}\n${ask}\n${suggested}\n\n${commentsProtocol}`;
 }
+
+export { SECTIONS, NEXT_QUESTION, detectors, missingSections, nextSection, guessCategoryFrom, guessClientFrom, buildStateNudge };
 
 /* ───────────────────────────── Handler Edge SSE ───────────────────────────── */
 export default async function handler(req) {

--- a/api/upload.js
+++ b/api/upload.js
@@ -106,7 +106,7 @@ function briefPrompt(texto, nombreArchivo) {
     {
       role: "user",
       content: `
-Base en el archivo "${nombreArchivo}". Texto (truncado):
+Basado en el archivo "${nombreArchivo}". Texto (truncado):
 """
 ${(texto || "").slice(0, 12000)}
 """

--- a/public/app.js
+++ b/public/app.js
@@ -14,6 +14,7 @@ const history = [];
 const MAX_TURNS = 20;
 
 let selectedFile = null;        // Se conserva para /api/finalize
+let seedUploaded = false;       // Evita reanalizar la misma semilla en cada turno
 let finalizeTriggered = false;  // Evita doble finalize
 
 // Comentarios ocultos que envía el asistente
@@ -52,6 +53,7 @@ function showInfo(msg) {
 /* ------------------------------ Archivo ------------------------------ */
 fileInput.addEventListener("change", () => {
   selectedFile = fileInput.files[0] || null;
+  seedUploaded = false;
 });
 
 /* ------------------------------ Auto-finalize ------------------------------ */
@@ -159,16 +161,17 @@ async function uploadFile(file) {
 /* ------------------------------ Enviar ------------------------------ */
 async function send() {
   const q = input.value.trim();
-  const file = fileInput.files[0];
+  const shouldUploadSeed = selectedFile && !seedUploaded;
 
-  if (!q && !file) return;
+  if (!q && !shouldUploadSeed) return;
 
   if (q) {
     addUserBubble(q);
     history.push({ role: "user", content: q });
   }
 
-  if (file) {
+  if (shouldUploadSeed) {
+    const file = selectedFile;
     // Subida para semilla (no crea nada en Drive)
     addUserBubble(`📎 Analizando **${file.name}**…`);
     try {
@@ -191,8 +194,8 @@ ${next}`.trim();
 
       history.push({ role: "assistant", content: seed });
       renderMarkdown(addBotContainer(), seed);
-      // No limpiamos selectedFile; se usa luego en / api/finalize
-      // fileInput.value = "";
+      seedUploaded = true;
+      if (fileInput) fileInput.value = "";
     } catch (err) {
       showWarning(`No pude procesar el archivo. Detalle: ${err?.message || err}`);
     }
@@ -205,12 +208,9 @@ ${next}`.trim();
 
 /* ------------------------------ Welcome / Reset ------------------------------ */
 function showWelcome() {
-  // Mensaje visible inicial para invitar a adjuntar documento
- // renderMarkdown(
-   // addBotContainer(),
-    //"💡 Si tienes un **documento** del proyecto (**PDF** o **DOCX**), adjúntalo desde el botón *Archivo* antes de empezar. Lo usaré para prellenar el brief."
- // );
-  // Respuesta inicial del asistente (SSE)
+  // El saludo inicial lo envía el backend vía SSE. Dejamos el snippet anterior
+  // comentado por si se quiere mostrar un mensaje estático antes de la respuesta
+  // en streaming.
   streamReply([]);
 }
 
@@ -219,6 +219,8 @@ function resetConversation() {
   history.length = 0;
   finalizeTriggered = false;
   selectedFile = null;
+  seedUploaded = false;
+  if (fileInput) fileInput.value = "";
   showWelcome();
   input.focus();
 }

--- a/tests/heuristics.test.js
+++ b/tests/heuristics.test.js
@@ -1,0 +1,109 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  detectors,
+  missingSections,
+  guessCategoryFrom,
+  guessClientFrom,
+  buildStateNudge,
+  SECTIONS,
+} from "../api/chat/stream.js";
+
+test("detectors recognize each section", () => {
+  assert.ok(detectors.Contacto("Juan Pérez juan@example.com"));
+  assert.strictEqual(detectors.Contacto("Juan sin correo"), false);
+
+  assert.ok(detectors.Alcance("Necesitamos un video, banners y más piezas para la campaña"));
+  assert.ok(detectors.Objetivos("Nuestro objetivo es awareness y conversiones"));
+  assert.ok(detectors.Audiencia("Audiencia: público joven y digital"));
+  assert.ok(detectors.Marca("La marca tiene un tono alegre y valores claros"));
+  assert.ok(detectors.Entregables("Entregables: formatos y versiones en video"));
+  assert.ok(detectors.Logística("Deadline 2024-12-01 con presupuesto y aprobaciones"));
+  assert.ok(detectors.Extras("Riesgos y referencias adicionales"));
+});
+
+test("missingSections omits completed sections", () => {
+  const messages = [
+    { role: "user", content: "Hola, soy Juan Pérez juan@example.com" },
+    {
+      role: "user",
+      content:
+        "El alcance del proyecto es un video para campaña digital y nuestro objetivo principal es awareness",
+    },
+  ];
+
+  const missing = missingSections(messages);
+  assert.ok(!missing.includes("Contacto"));
+  assert.ok(!missing.includes("Alcance"));
+  assert.ok(!missing.includes("Objetivos"));
+  assert.strictEqual(missing[0], "Audiencia");
+  assert.deepStrictEqual(
+    missing.filter((section) => !["Contacto", "Alcance", "Objetivos"].includes(section)),
+    missing,
+    "Solo deben faltar secciones posteriores"
+  );
+});
+
+test("guessCategoryFrom infers categories from keywords", () => {
+  assert.equal(guessCategoryFrom("Produciremos un spot de video para TV"), "Videos");
+  assert.equal(guessCategoryFrom("Es una campaña integral para la marca"), "Campaña");
+  assert.equal(guessCategoryFrom("Necesitamos refresh de branding y marca"), "Branding");
+  assert.equal(guessCategoryFrom("Queremos un nuevo sitio web"), "Web");
+  assert.equal(guessCategoryFrom("Prepararemos un evento híbrido"), "Evento");
+  assert.equal(guessCategoryFrom("Proyecto sin pistas"), "Proyecto");
+});
+
+test("guessClientFrom prioritizes email domains and labels", () => {
+  assert.equal(guessClientFrom("Contacto: ana@super-empresa.com"), "Super Empresa");
+  assert.equal(guessClientFrom("Cliente: Mega Studio S.A. de C.V."), "Mega");
+});
+
+test("buildStateNudge reflects progress and suggestions", () => {
+  const messages = [
+    { role: "user", content: "Juan Pérez juan@example.com" },
+    {
+      role: "user",
+      content: "Necesitamos un video para la campaña y el objetivo es awareness",
+    },
+  ];
+
+  const nudge = buildStateNudge(messages);
+
+  assert.match(nudge, /Sección \*\*Objetivos\*\* completada\. Ahora avanza a \*\*Audiencia\*\*\./);
+  assert.match(nudge, /Pregunta sugerida: "¿Quién es la audiencia/);
+
+  const expectedMissing = ["Audiencia", ...SECTIONS.slice(4)];
+  assert.match(
+    nudge,
+    new RegExp(
+      `<!-- PROGRESS: {\\"complete\\":false,\\"missing\\":\\[\\"${expectedMissing.join('\\",\\"')}\\"\\]} -->`
+    )
+  );
+});
+
+test("buildStateNudge signals completion with auto finalize", () => {
+  const messages = [
+    {
+      role: "user",
+      content: `
+Juan Pérez juan@super-empresa.com
+El alcance incluye video, banners y landing page para la campaña.
+Nuestros objetivos son awareness y conversiones.
+Audiencia: público joven en redes sociales.
+La marca tiene tono alegre, valores de innovación y referencias en el brandbook.
+Entregables: piezas en video y versiones 16:9.
+Logística: deadline 2024-12-01 con presupuesto tentativo y aprobaciones de dirección.
+Extras: riesgos mínimos y referencias https://ejemplo.com.
+      `.trim(),
+    },
+  ];
+
+  const nudge = buildStateNudge(messages);
+
+  assert.match(nudge, /\"complete\":true/);
+  assert.match(
+    nudge,
+    /<!-- AUTO_FINALIZE: {\"category\":\"Videos\",\"client\":\"Super Empresa\"} -->/
+  );
+});


### PR DESCRIPTION
## Summary
- fix the upload prompt typo so the seed request uses the intended phrasing
- prevent reusing the same file seed on every send, resetting the input and refreshing comments
- export and harden chat heuristics while adding node:test coverage for detectors and nudges

## Testing
- `node --test`


------
https://chatgpt.com/codex/tasks/task_b_68d330594f808330a6c0f286862b8fe4