### PR TITLE
Improve brief seed parsing in heuristics

### DIFF
--- a/api/chat/stream.js
+++ b/api/chat/stream.js
@@ -84,8 +84,57 @@ const detectors = {
 };
 
 /* ───────────────────────────── Utils ───────────────────────────── */
+const PREVIEW_LABELS = [...SECTIONS, "Fechas"];
+const SECTION_LABEL_PATTERN = PREVIEW_LABELS.map((s) => s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")).join("|");
+const SEED_LINE_RE = new RegExp(`^-\\s*(${SECTION_LABEL_PATTERN})\\s*:\\s*(.*)$`, "i");
+
+function normalizeUserText(raw = "") {
+  if (!raw) return "";
+
+  const lines = raw.split(/\r?\n/);
+  const cleaned = [];
+
+  for (const line of lines) {
+    const trimmed = line.trim();
+
+    if (!trimmed) {
+      cleaned.push(line);
+      continue;
+    }
+
+    if (/^\*\*Vista previa del archivo analizado\.\*\*/i.test(trimmed)) {
+      continue;
+    }
+
+    if (/^\*\*Faltantes:\*\*/i.test(trimmed)) {
+      continue;
+    }
+
+    const match = trimmed.match(SEED_LINE_RE);
+    if (match) {
+      let label = match[1].trim();
+      const value = match[2].trim();
+      const collapsed = value.replace(/\s+/g, "");
+      if (collapsed && !/^[-—]+$/.test(collapsed)) {
+        if (/^fechas$/i.test(label)) label = "Logística";
+        cleaned.push(`${label}: ${value}`);
+      }
+      continue;
+    }
+
+    cleaned.push(line);
+  }
+
+  return cleaned.join("\n");
+}
+
 const textFrom = (messages = [], roles = ["user"]) =>
-  messages.filter((m) => roles.includes(m?.role)).map((m) => m?.content || "").join("\n");
+  normalizeUserText(
+    messages
+      .filter((m) => roles.includes(m?.role))
+      .map((m) => m?.content || "")
+      .join("\n")
+  );
 
 const sectionCompleted = (s, userTxt) => {
   try {
@@ -129,10 +178,13 @@ function guessClientFrom(usersTxt = "") {
     if (dom) return titleCase(dom);
   }
   const m2 = usersTxt.match(/(?:Cliente|Empresa)\s*:\s*([^\n]+)/i);
-  if (m2?.[1])
-    return titleCase(
-      m2[1].replace(/\b(S\.?A\.?( de C\.?V\.?)?|SAS|SA|Ltd\.?|LLC|Studio|Estudio)\b/gi, "").trim()
-    );
+  if (m2?.[1]) {
+    const cleaned = m2[1]
+      .replace(/\b(S\.?A\.?( de C\.?V\.?)?|SAS|SA|Ltd\.?|LLC|Studio|Estudio)\b/gi, "")
+      .replace(/[.,\s]+$/g, "")
+      .trim();
+    if (cleaned) return titleCase(cleaned);
+  }
   return "Cliente";
 }
 
@@ -166,6 +218,8 @@ ${complete ? `<!-- AUTO_FINALIZE: ${JSON.stringify({ category: cat, client: cli 
 
   return `${progressLine}\n${ask}\n${suggested}\n\n${commentsProtocol}`;
 }
+
+export { SECTIONS, NEXT_QUESTION, detectors, missingSections, nextSection, guessCategoryFrom, guessClientFrom, buildStateNudge };
 
 /* ───────────────────────────── Handler Edge SSE ───────────────────────────── */
 export default async function handler(req) {

--- a/api/upload.js
+++ b/api/upload.js
@@ -106,7 +106,7 @@ function briefPrompt(texto, nombreArchivo) {
     {
       role: "user",
       content: `
-Base en el archivo "${nombreArchivo}". Texto (truncado):
+Basado en el archivo "${nombreArchivo}". Texto (truncado):
 """
 ${(texto || "").slice(0, 12000)}
 """

--- a/public/app.js
+++ b/public/app.js
@@ -14,11 +14,145 @@ const history = [];
 const MAX_TURNS = 20;
 
 let selectedFile = null;        // Se conserva para /api/finalize
+let seedUploaded = false;       // Evita reanalizar la misma semilla en cada turno
 let finalizeTriggered = false;  // Evita doble finalize
 
 // Comentarios ocultos que envía el asistente
 const PROGRESS_RE = /<!--\s*PROGRESS\s*:\s*(\{[\s\S]*?\})\s*-->/i;
 const AUTO_RE     = /<!--\s*AUTO_FINALIZE\s*:\s*(\{[\s\S]*?\})\s*-->/i;
+
+/* ------------------------------ Seed helpers ------------------------------ */
+function flattenSeedValue(value) {
+  if (value == null) return [];
+  if (typeof value === "string") {
+    const normalized = value.replace(/\s+/g, " ").trim();
+    return normalized ? [normalized] : [];
+  }
+  if (typeof value === "number" || typeof value === "boolean") {
+    return [String(value)];
+  }
+  if (Array.isArray(value)) {
+    return value.flatMap((item) => flattenSeedValue(item));
+  }
+  if (typeof value === "object") {
+    return Object.values(value).flatMap((item) => flattenSeedValue(item));
+  }
+  return [];
+}
+
+function dedupeParts(parts = []) {
+  const seen = new Set();
+  const out = [];
+  for (const part of parts) {
+    const trimmed = (part || "").trim();
+    if (!trimmed) continue;
+    const normalized = trimmed.toLowerCase();
+    if (seen.has(normalized)) continue;
+    seen.add(normalized);
+    out.push(trimmed);
+  }
+  return out;
+}
+
+function formatSeedValue(value, separator = ", ") {
+  const parts = dedupeParts(flattenSeedValue(value));
+  if (!parts.length) return "";
+  return parts.join(separator);
+}
+
+function formatContact(contacto) {
+  const parts = dedupeParts(flattenSeedValue(contacto));
+  if (!parts.length) return "";
+  const emailIdx = parts.findIndex((p) => /@/.test(p));
+  if (emailIdx >= 0) {
+    const [email] = parts.splice(emailIdx, 1);
+    parts.push(email);
+  }
+  return parts.join(" · ");
+}
+
+function formatAudiencia(audiencia) {
+  if (!audiencia) return "";
+  if (typeof audiencia !== "object" || audiencia instanceof Date) {
+    return formatSeedValue(audiencia);
+  }
+  const parts = [];
+  const descripcion = formatSeedValue(audiencia.descripcion);
+  if (descripcion) parts.push(descripcion);
+  const canales = formatSeedValue(audiencia.canales);
+  if (canales) parts.push(`Canales: ${canales}`);
+  for (const [key, value] of Object.entries(audiencia)) {
+    if (key === "descripcion" || key === "canales") continue;
+    const val = formatSeedValue(value);
+    if (val) parts.push(val);
+  }
+  return dedupeParts(parts).join(". ");
+}
+
+function formatMarca(marca) {
+  if (!marca) return "";
+  if (typeof marca !== "object" || marca instanceof Date) {
+    return formatSeedValue(marca);
+  }
+  const parts = [];
+  const tono = formatSeedValue(marca.tono);
+  if (tono) parts.push(`Tono: ${tono}`);
+  const valores = formatSeedValue(marca.valores);
+  if (valores) parts.push(`Valores: ${valores}`);
+  const referencias = formatSeedValue(marca.referencias);
+  if (referencias) parts.push(`Referencias: ${referencias}`);
+  for (const [key, value] of Object.entries(marca)) {
+    if (["tono", "valores", "referencias"].includes(key)) continue;
+    const val = formatSeedValue(value);
+    if (val) parts.push(val);
+  }
+  return dedupeParts(parts).join(". ");
+}
+
+function formatLogistica(logistica) {
+  if (!logistica) return "";
+  if (typeof logistica !== "object" || logistica instanceof Date) {
+    return formatSeedValue(logistica);
+  }
+  if (Array.isArray(logistica)) {
+    return formatSeedValue(logistica);
+  }
+  const parts = [];
+  const fechas = formatSeedValue(logistica.fechas);
+  if (fechas) parts.push(fechas);
+  const presupuesto = formatSeedValue(logistica.presupuesto, " ");
+  if (presupuesto) parts.push(`Presupuesto: ${presupuesto}`);
+  const aprobaciones = formatSeedValue(logistica.aprobaciones);
+  if (aprobaciones) parts.push(`Aprobaciones: ${aprobaciones}`);
+  for (const [key, value] of Object.entries(logistica)) {
+    if (["fechas", "presupuesto", "aprobaciones"].includes(key)) continue;
+    const val = formatSeedValue(value);
+    if (val) parts.push(val);
+  }
+  return dedupeParts(parts).join("; ");
+}
+
+function formatExtras(extras) {
+  if (!extras) return "";
+  if (typeof extras !== "object" || extras instanceof Date) {
+    return formatSeedValue(extras);
+  }
+  const parts = [];
+  const riesgos = formatSeedValue(extras.riesgos);
+  if (riesgos) parts.push(`Riesgos: ${riesgos}`);
+  const notas = formatSeedValue(extras.notas);
+  if (notas) parts.push(notas);
+  for (const [key, value] of Object.entries(extras)) {
+    if (["riesgos", "notas"].includes(key)) continue;
+    const val = formatSeedValue(value);
+    if (val) parts.push(val);
+  }
+  return dedupeParts(parts).join(". ");
+}
+
+function withFallback(text) {
+  return text && text.trim() ? text.trim() : "—";
+}
 
 /* ------------------------------ UI helpers ------------------------------ */
 function addUserBubble(text) {
@@ -52,6 +186,7 @@ function showInfo(msg) {
 /* ------------------------------ Archivo ------------------------------ */
 fileInput.addEventListener("change", () => {
   selectedFile = fileInput.files[0] || null;
+  seedUploaded = false;
 });
 
 /* ------------------------------ Auto-finalize ------------------------------ */
@@ -159,16 +294,20 @@ async function uploadFile(file) {
 /* ------------------------------ Enviar ------------------------------ */
 async function send() {
   const q = input.value.trim();
-  const file = fileInput.files[0];
+  const shouldUploadSeed = selectedFile && !seedUploaded;
 
-  if (!q && !file) return;
+  if (!q && !shouldUploadSeed) return;
+
+  let pendingUserEntry = null;
 
   if (q) {
     addUserBubble(q);
-    history.push({ role: "user", content: q });
+    pendingUserEntry = { role: "user", content: q };
+    history.push(pendingUserEntry);
   }
 
-  if (file) {
+  if (shouldUploadSeed) {
+    const file = selectedFile;
     // Subida para semilla (no crea nada en Drive)
     addUserBubble(`📎 Analizando **${file.name}**…`);
     try {
@@ -179,20 +318,29 @@ async function send() {
 
       const seed = `
 **Vista previa del archivo analizado.**
-- Alcance: ${b.alcance || "—"}
-- Objetivos: ${Array.isArray(b.objetivos) && b.objetivos.length ? b.objetivos.join(", ") : "—"}
-- Audiencia: ${b.audiencia?.descripcion || "—"}
-- Entregables: ${Array.isArray(b.entregables) && b.entregables.length ? b.entregables.join(", ") : "—"}
-- Fechas: ${Array.isArray(b.logistica?.fechas) && b.logistica.fechas.length ? b.logistica.fechas.join(", ") : "—"}
+- Contacto: ${withFallback(formatContact(b.contacto))}
+- Alcance: ${withFallback(formatSeedValue(b.alcance))}
+- Objetivos: ${withFallback(formatSeedValue(b.objetivos))}
+- Audiencia: ${withFallback(formatAudiencia(b.audiencia))}
+- Marca: ${withFallback(formatMarca(b.marca))}
+- Entregables: ${withFallback(formatSeedValue(b.entregables))}
+- Logística: ${withFallback(formatLogistica(b.logistica))}
+- Extras: ${withFallback(formatExtras(b.extras))}
 
 **Faltantes:** ${faltan.length ? faltan.join(", ") : "—"}
 
 ${next}`.trim();
 
-      history.push({ role: "assistant", content: seed });
+      if (pendingUserEntry) {
+        pendingUserEntry.content = [pendingUserEntry.content, seed]
+          .filter(Boolean)
+          .join("\n\n");
+      } else {
+        history.push({ role: "user", content: seed });
+      }
       renderMarkdown(addBotContainer(), seed);
-      // No limpiamos selectedFile; se usa luego en / api/finalize
-      // fileInput.value = "";
+      seedUploaded = true;
+      if (fileInput) fileInput.value = "";
     } catch (err) {
       showWarning(`No pude procesar el archivo. Detalle: ${err?.message || err}`);
     }
@@ -205,12 +353,9 @@ ${next}`.trim();
 
 /* ------------------------------ Welcome / Reset ------------------------------ */
 function showWelcome() {
-  // Mensaje visible inicial para invitar a adjuntar documento
- // renderMarkdown(
-   // addBotContainer(),
-    //"💡 Si tienes un **documento** del proyecto (**PDF** o **DOCX**), adjúntalo desde el botón *Archivo* antes de empezar. Lo usaré para prellenar el brief."
- // );
-  // Respuesta inicial del asistente (SSE)
+  // El saludo inicial lo envía el backend vía SSE. Dejamos el snippet anterior
+  // comentado por si se quiere mostrar un mensaje estático antes de la respuesta
+  // en streaming.
   streamReply([]);
 }
 
@@ -219,6 +364,8 @@ function resetConversation() {
   history.length = 0;
   finalizeTriggered = false;
   selectedFile = null;
+  seedUploaded = false;
+  if (fileInput) fileInput.value = "";
   showWelcome();
   input.focus();
 }

--- a/tests/heuristics.test.js
+++ b/tests/heuristics.test.js
@@ -1,0 +1,157 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  detectors,
+  missingSections,
+  guessCategoryFrom,
+  guessClientFrom,
+  buildStateNudge,
+  SECTIONS,
+} from "../api/chat/stream.js";
+
+test("detectors recognize each section", () => {
+  assert.ok(detectors.Contacto("Juan Pérez juan@example.com"));
+  assert.strictEqual(detectors.Contacto("Juan sin correo"), false);
+
+  assert.ok(detectors.Alcance("Necesitamos un video, banners y más piezas para la campaña"));
+  assert.ok(detectors.Objetivos("Nuestro objetivo es awareness y conversiones"));
+  assert.ok(detectors.Audiencia("Audiencia: público joven y digital"));
+  assert.ok(detectors.Marca("La marca tiene un tono alegre y valores claros"));
+  assert.ok(detectors.Entregables("Entregables: formatos y versiones en video"));
+  assert.ok(detectors.Logística("Deadline 2024-12-01 con presupuesto y aprobaciones"));
+  assert.ok(detectors.Extras("Riesgos y referencias adicionales"));
+});
+
+test("missingSections omits completed sections", () => {
+  const messages = [
+    { role: "user", content: "Hola, soy Juan Pérez juan@example.com" },
+    {
+      role: "user",
+      content:
+        "El alcance del proyecto es un video para campaña digital y nuestro objetivo principal es awareness",
+    },
+  ];
+
+  const missing = missingSections(messages);
+  assert.ok(!missing.includes("Contacto"));
+  assert.ok(!missing.includes("Alcance"));
+  assert.ok(!missing.includes("Objetivos"));
+  assert.strictEqual(missing[0], "Audiencia");
+  assert.deepStrictEqual(
+    missing.filter((section) => !["Contacto", "Alcance", "Objetivos"].includes(section)),
+    missing,
+    "Solo deben faltar secciones posteriores"
+  );
+});
+
+test("missingSections ignores seed placeholders with em dashes", () => {
+  const messages = [
+    {
+      role: "user",
+      content: `
+**Vista previa del archivo analizado.**
+- Contacto: —
+- Alcance: —
+- Objetivos: —
+- Audiencia: —
+- Marca: —
+- Entregables: —
+- Logística: —
+- Extras: —
+
+**Faltantes:** Alcance, Objetivos, Audiencia, Marca, Entregables, Logística, Extras
+
+¿Seguimos con la siguiente sección?
+      `.trim(),
+    },
+  ];
+
+  const missing = missingSections(messages);
+  assert.deepStrictEqual(missing, SECTIONS);
+});
+
+test("missingSections leverages seed values when provided", () => {
+  const messages = [
+    {
+      role: "user",
+      content: `
+**Vista previa del archivo analizado.**
+- Contacto: Juan Pérez · juan@example.com
+- Alcance: Necesitamos un video y banners para campaña digital.
+- Objetivos: Aumentar awareness y conversiones.
+- Audiencia: Público joven urbano en redes sociales.
+- Marca: Tono: alegre. Valores: innovación.
+- Entregables: Videos 30s y versiones cuadradas.
+- Logística: Deadline 2024-12-01 con presupuesto tentativo y aprobaciones clave.
+- Extras: Riesgos mínimos y referencias https://ejemplo.com.
+      `.trim(),
+    },
+  ];
+
+  const missing = missingSections(messages);
+  assert.deepStrictEqual(missing, []);
+});
+
+test("guessCategoryFrom infers categories from keywords", () => {
+  assert.equal(guessCategoryFrom("Produciremos un spot de video para TV"), "Videos");
+  assert.equal(guessCategoryFrom("Es una campaña integral para la marca"), "Campaña");
+  assert.equal(guessCategoryFrom("Necesitamos refresh de branding y marca"), "Branding");
+  assert.equal(guessCategoryFrom("Queremos un nuevo sitio web"), "Web");
+  assert.equal(guessCategoryFrom("Prepararemos un evento híbrido"), "Evento");
+  assert.equal(guessCategoryFrom("Proyecto sin pistas"), "Proyecto");
+});
+
+test("guessClientFrom prioritizes email domains and labels", () => {
+  assert.equal(guessClientFrom("Contacto: ana@super-empresa.com"), "Super Empresa");
+  assert.equal(guessClientFrom("Cliente: Mega Studio S.A. de C.V."), "Mega");
+});
+
+test("buildStateNudge reflects progress and suggestions", () => {
+  const messages = [
+    { role: "user", content: "Juan Pérez juan@example.com" },
+    {
+      role: "user",
+      content: "Necesitamos un video para la campaña y el objetivo es awareness",
+    },
+  ];
+
+  const nudge = buildStateNudge(messages);
+
+  assert.match(nudge, /Sección \*\*Objetivos\*\* completada\. Ahora avanza a \*\*Audiencia\*\*\./);
+  assert.match(nudge, /Pregunta sugerida: "¿Quién es la audiencia/);
+
+  const expectedMissing = ["Audiencia", ...SECTIONS.slice(4)];
+  assert.match(
+    nudge,
+    new RegExp(
+      `<!-- PROGRESS: {\\"complete\\":false,\\"missing\\":\\[\\"${expectedMissing.join('\\",\\"')}\\"\\]} -->`
+    )
+  );
+});
+
+test("buildStateNudge signals completion with auto finalize", () => {
+  const messages = [
+    {
+      role: "user",
+      content: `
+Juan Pérez juan@super-empresa.com
+El alcance incluye video, banners y landing page para la campaña.
+Nuestros objetivos son awareness y conversiones.
+Audiencia: público joven en redes sociales.
+La marca tiene tono alegre, valores de innovación y referencias en el brandbook.
+Entregables: piezas en video y versiones 16:9.
+Logística: deadline 2024-12-01 con presupuesto tentativo y aprobaciones de dirección.
+Extras: riesgos mínimos y referencias https://ejemplo.com.
+      `.trim(),
+    },
+  ];
+
+  const nudge = buildStateNudge(messages);
+
+  assert.match(nudge, /\"complete\":true/);
+  assert.match(
+    nudge,
+    /<!-- AUTO_FINALIZE: {\"category\":\"Videos\",\"client\":\"Super Empresa\"} -->/
+  );
+});


### PR DESCRIPTION
## Summary
- expand the client-side seed preview so uploaded briefs populate contact, marca, logística and extras while coercing varied JSON shapes instead of defaulting to em dashes
- keep preview labels when normalizing chat text (mapping "Fechas" to "Logística") so heuristics still ignore placeholders yet credit the uploaded values
- refresh heuristic tests to cover the richer seed preview and confirm document data removes sections from the missing list

## Testing
- node --test

------
https://chatgpt.com/codex/tasks/task_b_68d330594f808330a6c0f286862b8fe4